### PR TITLE
[Feat] Bicycle Producer 작성 #6

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,6 +20,12 @@ jobs:
       # actions/checkout@4는 본 레파지토리의 내용을 checkout 하여 runner 서버에 저장함
       uses: actions/checkout@v4
 
+    # application.yml 파일 내 ## 부분을 실제 값을 변경(서울시 공공데이터 인증키)
+    - name: replace application.yml
+      env:
+        AUTH_KEY_SEOUL_DATA: ${{ secrets.AUTH_KEY_SEOUL_DATA }}
+      run: sed -ie "s/##auth_key_seoul_data##/$AUTH_KEY_SEOUL_DATA/g" ./config/application.yml
+
     - name: archive to tar.gz
       run: tar cvfz ./kafka-producer.tar.gz *
 

--- a/apis/seoul_data/realtime_bicycle.py
+++ b/apis/seoul_data/realtime_bicycle.py
@@ -1,0 +1,7 @@
+class RealtimeBicycle:
+
+    def __init__(self):
+        self.auth_key = '##auth_key_seoul_data##'
+
+    def call_api(self):
+        pass

--- a/apis/seoul_data/realtime_bicycle.py
+++ b/apis/seoul_data/realtime_bicycle.py
@@ -26,8 +26,8 @@ class RealtimeBicycle:
         total_rows = []
         while True:
             try:
-                rslt = self._call_api(base_url, start, end)
-                contents = json.loads(rslt.text)
+                result = self._call_api(base_url, start, end)
+                contents = json.loads(result.text)
             except JSONDecodeError:
                 self.log.error(f'요청 실패, {traceback.format_exc()}')
                 time.sleep(30)  # 30초 대기 후 재시도

--- a/apis/seoul_data/realtime_bicycle.py
+++ b/apis/seoul_data/realtime_bicycle.py
@@ -46,6 +46,7 @@ class RealtimeBicycle:
                     self.log.error(f'요청 실패, 에러코드: {result_code}, 메시지:{result_msg}')
                     time.sleep(30)      # 30초 대기
 
+            # 정상인 경우 처리
             key_nm = list(contents.keys())[0]
             items = contents.get(key_nm)
             item_cnt = items.get('list_total_count')
@@ -69,8 +70,8 @@ class RealtimeBicycle:
             url = f'{base_url}/{start}/{end}/{base_dt}'
         else:
             url = f'{base_url}/{start}/{end}'
-        rslt = requests.get(url, headers)
-        return rslt
+        result = requests.get(url, headers)
+        return result
 
     def chk_dir(self):
         os.makedirs(self.log_dir, exist_ok=True)

--- a/apis/seoul_data/realtime_bicycle.py
+++ b/apis/seoul_data/realtime_bicycle.py
@@ -1,7 +1,97 @@
+import requests
+import json
+from json.decoder import JSONDecodeError
+import logging
+from logging.handlers import TimedRotatingFileHandler
+import time
+import os
+import traceback
+
+
 class RealtimeBicycle:
 
-    def __init__(self):
+    def __init__(self, dataset_nm):
         self.auth_key = '##auth_key_seoul_data##'
+        self.api_url = 'http://openapi.seoul.go.kr:8088'
+        self.log_dir = '/log/seoul_api'
+        self.dataset_nm = dataset_nm
+        self.chk_dir()
+        self.log = self._get_logger()
 
-    def call_api(self):
-        pass
+    def call(self):
+        # url 형태: http://openapi.seoul.go.kr:8088/(인증키)/json/bikeList/1/5/
+        base_url = f'{self.api_url}/{self.auth_key}/json/{self.dataset_nm}'
+        start = 1
+        end = 1000
+        total_rows = []
+        while True:
+            try:
+                rslt = self._call_api(base_url, start, end)
+                contents = json.loads(rslt.text)
+            except JSONDecodeError:
+                self.log.error(f'요청 실패, {traceback.format_exc()}')
+                time.sleep(30)  # 30초 대기 후 재시도
+                continue
+
+
+            # 정상이 아닌 경우 처리
+            result_code = contents.get('CODE')
+            if result_code:
+                # INFO-200: 해당하는 데이터 없음. total_rows 리스트에 값이 존재할 경우
+                # 조회 범위 초과로 에러 발생한 것이며 결과 리턴하고 종료
+                if result_code == 'INFO-200' and total_rows:
+                    return total_rows
+                else:
+                    result_msg = contents.get('MESSAGE')
+                    self.log.error(f'요청 실패, 에러코드: {result_code}, 메시지:{result_msg}')
+                    time.sleep(30)      # 30초 대기
+
+            key_nm = list(contents.keys())[0]
+            items = contents.get(key_nm)
+            item_cnt = items.get('list_total_count')
+            item_row = items.get('row')
+            self.log.info(f'{base_url}/{start}/{end} 조회 성공, 건수: {len(item_row)}')
+            if item_row:
+                total_rows += item_row
+            if item_cnt < 1000:
+                break
+            else:
+                start = end + 1
+                end += 1000
+        return total_rows
+
+    def _call_api(self, base_url, start, end, base_dt=''):
+        headers = {'Content-Type': 'application/json',
+                   'charset': 'utf-8',
+                   'Accept': '*/*'
+                   }
+        if len(base_dt) > 0:
+            url = f'{base_url}/{start}/{end}/{base_dt}'
+        else:
+            url = f'{base_url}/{start}/{end}'
+        rslt = requests.get(url, headers)
+        return rslt
+
+    def chk_dir(self):
+        os.makedirs(self.log_dir, exist_ok=True)
+
+    def _get_logger(self):
+        default_format = '%(asctime)s [%(levelname)s]:%(message)s'
+        logging.basicConfig(
+            format=default_format,
+            level=logging.INFO,
+            datefmt='%Y-%m-%d %H:%M:%S'
+        )
+        formatter = logging.Formatter(default_format)
+        handler = TimedRotatingFileHandler(os.path.join(self.log_dir, 'call_bicycle_api.log'), when="midnight", backupCount=7)
+        handler.suffix = "%Y-%m-%d"
+        handler.setFormatter(formatter)
+        logger = logging.getLogger(__name__)
+        logger.addHandler(handler)
+
+        return logger
+
+
+real_bicycle = RealtimeBicycle(dataset_nm='bikeList')
+items = real_bicycle.call()
+print(items[0:10])

--- a/config/application.yml
+++ b/config/application.yml
@@ -1,0 +1,2 @@
+api_key:
+  auth_key_seoul_data: ##auth_key_seoul_data##

--- a/deploy/after_install.sh
+++ b/deploy/after_install.sh
@@ -1,2 +1,3 @@
 source /src/kafka_venv/bin/activate
+python3 /src/kafka-producer/deploy/replace_secret.py
 pip3 install -r /src/kafka-producer/requirements.txt

--- a/deploy/replace_secret.py
+++ b/deploy/replace_secret.py
@@ -1,0 +1,27 @@
+import yaml
+import os
+
+root_dir = '/src/kafka-producer'
+with open(f'{root_dir}/config/application.yml','r') as config:
+    all_conf_dict = yaml.load(config, Loader=yaml.FullLoader)
+
+for (root, dirs, files) in os.walk(root_dir):
+    # root는 문자열로, dirs와 files는 리스트로 리턴됨
+    if root.find('/.git') > 0 or root.find('/config/') > 0 or root.find('/.github/') > 0:
+        # 치환 불필요 디렉토리
+        continue
+
+    # files 가 1개 이상 있을 경우 실행
+    if len(files) > 0:
+        for file in files:
+            # 치환 대상은 .py 파일만 대상으로 함
+            if file.endswith('.py'):
+                with open(f'{root}/{file}', 'r', encoding='utf-8') as file_read:
+                    py_file_all = ''.join(file_read.readlines())
+                    with open(f'{root}/{file}', 'w', encoding='utf-8') as file_write:
+
+                        # application.yml 파일의 모든 키, 값 쌍을 읽어 replace
+                        for conf_item_dict in list(all_conf_dict.values()):
+                            for k, v in conf_item_dict.items():
+                                py_file_all = py_file_all.replace(f'##{k}##',v)
+                            file_write.write(py_file_all)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 confluent-kafka==2.11.1
 PyYAML==6.0.2
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 confluent-kafka==2.11.1
 PyYAML==6.0.2
-requests


### PR DESCRIPTION
## 🔗 관련 이슈

> #6

## 💡 작업 내용

- 공공자전거 API 호출하여 데이터 받아오는 프로그램 작성
- 인증 키와 같은 민감정보 관리
- Bicycle Producer 작성

## 📝 추가 설명(선택)

### 공공자전거 API 호출하여 데이터 받아오는 프로그램 작성
  - 15초 간격으로 API를 호출합니다.
  - 서버의 /log/seoul_api/call_bicycle_api.log 파일 내 호출 기록 저장합니다.
  - 해당 파일은 daliy location 되며, 7일이 지나면 삭제됩니다.

### Bycicle Producer 구현
  - Kafka Topic : apis.seouldata.rt-bicycle

### 서울시 공공데이터 인증키 관리
  - Actions의 Secret 활용하여 application.yml 파일의 대체값을 실제 민감정보로 치환됩니다.
  - codeDeploy의 AfterInstall(hooks)을 활용하여 모든 파이썬 파일의 대체값을 application.yml 기준 민감정보로 치환됩니다.

### 편의를 위해 Producer 프로그램을 demon으로 등록했습니다.
  - Producer 가 daemon 서비스로 구동기에, git코드 배포시 CI/CD에 의해 daemon재시작하도록 구성할 수 있습니다.
  - AWS Code deploy 서비스의 ApplicationStart후크를 이용해 daemon로직을 추가했습니다.

## 📚 참고 자료(선택)

> 필요한 자료나 사진을 첨부해주세요