### PR TITLE
[Feat] Bicycle Producer 작성 #6

### DIFF
--- a/producers/bicycle_producer.py
+++ b/producers/bicycle_producer.py
@@ -1,0 +1,84 @@
+import time
+import json
+import logging
+from confluent_kafka import Producer
+from apis.seoul_data.realtime_bicycle import RealtimeBicycle
+from datetime import datetime
+
+
+BROKER_LST = 'kafka01:9092,kafka02:9092,kafka03:9092'
+
+
+class BicycleProducer():
+
+    def __init__(self, topic):
+        self.topic = topic
+        self.conf = {'bootstrap.servers': BROKER_LST}
+        self.producer = Producer(self.conf)
+        self._set_logger()
+
+    def _set_logger(self):
+        logging.basicConfig(
+            format='%(asctime)s [%(levelname)s]:%(message)s',
+            level=logging.INFO,
+            datefmt='%Y-%m-%d %H:%M:%S'
+        )
+        self.log = logging.getLogger(__name__)
+
+    # Optional per-message delivery callback (triggered by poll() or flush())
+    # when a message has been successfully delivered or permanently
+    # failed delivery (after retries).
+    def delivery_callback(self, err, msg):
+        if err:
+            self.log.error('%% Message failed delivery: %s\n' % err)
+        else:
+            pass
+
+    def produce(self):
+        rt_bicycle = RealtimeBicycle(dataset_nm='bikeList')
+        while True:
+            now_dt = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+            items = rt_bicycle.call()
+            for item in items:
+                # 컬럼명 변경
+                item['STT_ID'] = item.pop('stationId')
+                item['STT_NM'] = item.pop('stationName')
+                item['TOT_RACK_CNT'] = item.pop('rackTotCnt')
+                item['TOT_PRK_CNT'] = item.pop('parkingBikeTotCnt')
+                item['RATIO_PRK_RACK'] = item.pop('shared')
+                item['STT_LTTD'] = item.pop('stationLatitude')
+                item['STT_LGTD'] = item.pop('stationLongitude')
+
+                # 컬럼 추가
+                item['CRT_DTTM'] = now_dt
+
+                # produce
+                try:
+                    self.producer.produce(
+                        topic=self.topic,
+                        key=json.dumps({'STT_ID': item['STT_ID'],'CRT_DTTM':item['CRT_DTTM']}, ensure_ascii=False),
+                        value=json.dumps(item, ensure_ascii=False),
+                        on_delivery=self.delivery_callback
+                    )
+
+                except BufferError:
+                    self.log.error('%% Local producer queue is full (%d messages awaiting delivery): try again\n' %
+                                     len(self.producer))
+
+            # Serve delivery callback queue.
+            # NOTE: Since produce() is an asynchronous API this poll() call
+            #       will most likely not serve the delivery callback for the
+            #       last produce()d message.
+            self.producer.poll(0)
+
+            # Wait until all messages have been delivered
+            self.log.info('%% Waiting for %d deliveries\n' % len(self.producer))
+            self.producer.flush()
+
+            # 15초 대기
+            time.sleep(15)
+
+
+if __name__ == '__main__':
+    bicycle_producer = BicycleProducer(topic='apis.seouldata.rt-bicycle')
+    bicycle_producer.produce()


### PR DESCRIPTION
## 🔗 관련 이슈

> #6

## 💡 작업 내용

- 공공자전거 API 호출하여 데이터 받아오는 프로그램 작성
- 인증 키와 같은 민감정보 관리
- Bicycle Producer 작성

## 📝 추가 설명(선택)

### 공공자전거 API 호출하여 데이터 받아오는 프로그램 작성
  - 15초 간격으로 API를 호출합니다.
  - 서버의 /log/seoul_api/call_bicycle_api.log 파일 내 호출 기록 저장합니다.
  - 해당 파일은 daliy location 되며, 7일이 지나면 삭제됩니다.

### Bycicle Producer 구현
  - Kafka Topic : apis.seouldata.rt-bicycle

### 서울시 공공데이터 인증키 관리
  - Actions의 Secret 활용하여 application.yml 파일의 대체값을 실제 민감정보로 치환됩니다.
  - codeDeploy의 AfterInstall(hooks)을 활용하여 모든 파이썬 파일의 대체값을 application.yml 기준 민감정보로 치환됩니다.

### 편의를 위해 Producer 프로그램을 demon으로 등록했습니다.
  - Producer 가 daemon 서비스로 구동기에, git코드 배포시 CI/CD에 의해 daemon재시작하도록 구성할 수 있습니다.
  - AWS Code deploy 서비스의 ApplicationStart후크를 이용해 daemon로직을 추가했습니다.

## 📚 참고 자료(선택)

> 필요한 자료나 사진을 첨부해주세요