### PR TITLE
[Feat] Kafka 클러스터 모니터링 시스템 구축 #6

### DIFF
--- a/docker-compose/kafka03/docker-compose.yaml
+++ b/docker-compose/kafka03/docker-compose.yaml
@@ -1,0 +1,46 @@
+---
+services:
+  kafka-exporter:
+    image: danielqsj/kafka-exporter
+    container_name: kafka-exporter
+    restart: always
+    command: [ "--kafka.server=kafka01:9092", "--kafka.server=kafka02:9092", "--kafka.server=kafka03:9092" ]
+    expose:
+      - 9308
+    networks:
+      - kpg_network
+
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    restart: always
+    user: 1001:1000
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.retention.time=168h'
+    volumes:
+      - /src/kafka-producer/docker-compose/kafka03/prometheus.yml:/etc/prometheus/prometheus.yml
+      - /data/prometheus/data:/prometheus
+    ports:
+      - 9090:9090
+    networks:
+      - kpg_network
+
+  grafana:
+    image: grafana/grafana-enterprise:11.4.0
+    container_name: grafana
+    restart: always
+    user: 1001:1000
+    ports:
+      - 3000:3000
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - /data/grafana/data:/var/lib/grafana
+    networks:
+      - kpg_network
+
+networks:
+  kpg_network:
+    driver: bridge

--- a/docker-compose/kafka03/prometheus.yml
+++ b/docker-compose/kafka03/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+scrape_configs:
+  - job_name: 'kafka_exporter'
+    static_configs:
+      - targets: [ 'kafka-exporter:9308' ]


### PR DESCRIPTION
## 🔗 관련 이슈

- #9

## 💡 작업 내용

- Kafka Exporter: Kafka 클러스터(kafka01, kafka02, kafka03)에 접속하여 성능 관련 메트릭(데이터)을 수집
- UI For Apache Kafka와 마찬가지로 Prometheus, Exporter, Grafana 역시 Broker Cluster와 분리된 환경에 구성하는 것이 바람직하나 여건상 Broker 서버에 Docker 컨테이너로 구축(Kafka03)
- kafka-ui와 마찬가지로 Exporter, Prometheus, Grafana는 Kafka Broker에 올리는 서비스이므로 docker-compose.yaml 파일은 git을 통해 관리하고 배포되도록 구성
- Kafka 클러스터의 모니터링 시스템을 구축하기 위한 Docker 컨테이너들을 정의


## 📝 추가 설명(선택)

- Kafka Exporter: Kafka 클러스터(kafka01, kafka02, kafka03)에 접속하여 성능 관련 메트릭(데이터)을 수집
- Prometheus: 주기적으로 Kafka Exporter에 접근하여 수집된 메트릭을 가져와 자신의 데이터베이스에 저장
- Grafana: Prometheus를 데이터 소스로 사용하여, 저장된 메트릭을 사용자가 보기 쉬운 그래프나 차트 형태의 대시보드로 시각화

## 📚 참고 자료(선택)
<img width="577" height="305" alt="image" src="https://github.com/user-attachments/assets/488f62d6-0cdf-4988-8e8f-fbc2a543c063" />

<img width="693" height="318" alt="Image" src="https://github.com/user-attachments/assets/2ac338ab-4dde-49b7-b258-9101bf1c1cf4" />
